### PR TITLE
Added filtring by datetime and ordering type selection.

### DIFF
--- a/01. Presentation/NewHabr.WebApi/Controllers/ArticlesController.cs
+++ b/01. Presentation/NewHabr.WebApi/Controllers/ArticlesController.cs
@@ -66,12 +66,12 @@ public class ArticlesController : ControllerBase
 
     [HttpGet]
     public async Task<ActionResult<ArticlesGetResponse>> GetPublished(
-        [FromQuery] ArticleQueryParameters queryParams,
+        [FromQuery] ArticleQueryParametersDto queryParamsDto,
         CancellationToken cancellationToken)
     {
         try
         {
-            return Ok(await _articleService.GetPublishedAsync(queryParams, cancellationToken));
+            return Ok(await _articleService.GetPublishedAsync(queryParamsDto, cancellationToken));
         }
         catch (Exception ex)
         {
@@ -82,12 +82,12 @@ public class ArticlesController : ControllerBase
 
     [HttpGet("unpublished")]
     public async Task<ActionResult<ArticlesGetResponse>> GetUnpublished(
-        [FromQuery] ArticleQueryParameters queryParams,
+        [FromQuery] ArticleQueryParametersDto queryParamsDto,
         CancellationToken cancellationToken)
     {
         try
         {
-            return Ok(await _articleService.GetUnpublishedAsync(queryParams, cancellationToken));
+            return Ok(await _articleService.GetUnpublishedAsync(queryParamsDto, cancellationToken));
         }
         catch (Exception ex)
         {
@@ -98,12 +98,12 @@ public class ArticlesController : ControllerBase
 
     [HttpGet("deleted")]
     public async Task<ActionResult<ArticlesGetResponse>> GetDeleted(
-        [FromQuery] ArticleQueryParameters queryParams,
+        [FromQuery] ArticleQueryParametersDto queryParamsDto,
         CancellationToken cancellationToken)
     {
         try
         {
-            return Ok(await _articleService.GetDeletedAsync(queryParams, cancellationToken));
+            return Ok(await _articleService.GetDeletedAsync(queryParamsDto, cancellationToken));
         }
         catch (Exception ex)
         {

--- a/02. Business/NewHabr.Business/AutoMapperProfiles/ArticleProfile.cs
+++ b/02. Business/NewHabr.Business/AutoMapperProfiles/ArticleProfile.cs
@@ -27,5 +27,9 @@ public class ArticleProfile : Profile
             .ForMember(dest => dest.Tags, options => options.Ignore());
 
         CreateMap<ArticleExt, ArticleDto>();
+
+        CreateMap<ArticleQueryParametersDto, ArticleQueryParameters>()
+            .ForMember(dest => dest.From, e => e.MapFrom(src => DateTimeOffset.FromUnixTimeMilliseconds(src.From)))
+            .ForMember(dest => dest.To, e => e.MapFrom(src => DateTimeOffset.FromUnixTimeMilliseconds(src.To)));
     }
 }

--- a/02. Business/NewHabr.Business/Services/ArticleService.cs
+++ b/02. Business/NewHabr.Business/Services/ArticleService.cs
@@ -1,5 +1,4 @@
 ﻿using AutoMapper;
-using Microsoft.AspNetCore.Identity;
 using NewHabr.Business.Extensions;
 using NewHabr.Domain.Contracts;
 using NewHabr.Domain.Contracts.Services;

--- a/02. Business/NewHabr.Business/Services/ArticleService.cs
+++ b/02. Business/NewHabr.Business/Services/ArticleService.cs
@@ -61,9 +61,10 @@ public class ArticleService : IArticleService
     }
 
     public async Task<ArticlesGetResponse> GetPublishedAsync(
-        ArticleQueryParameters queryParams,
+        ArticleQueryParametersDto queryParamsDto,
         CancellationToken cancellationToken)
     {
+        var queryParams = _mapper.Map<ArticleQueryParameters>(queryParamsDto);
         var articles = await _repositoryManager.ArticleRepository.GetPublishedIncludeAsync(queryParams, false, cancellationToken);
         return new ArticlesGetResponse
         {
@@ -73,9 +74,10 @@ public class ArticleService : IArticleService
     }
 
     public async Task<ArticlesGetResponse> GetUnpublishedAsync(
-        ArticleQueryParameters queryParams,
+        ArticleQueryParametersDto queryParamsDto,
         CancellationToken cancellationToken)
     {
+        var queryParams = _mapper.Map<ArticleQueryParameters>(queryParamsDto);
         var articles = await _repositoryManager.ArticleRepository.GetUnpublishedIncludeAsync(queryParams, false, cancellationToken);
         return new ArticlesGetResponse
         {
@@ -85,9 +87,10 @@ public class ArticleService : IArticleService
     }
 
     public async Task<ArticlesGetResponse> GetDeletedAsync(
-        ArticleQueryParameters queryParams,
+        ArticleQueryParametersDto queryParamsDto,
         CancellationToken cancellationToken)
     {
+        var queryParams = _mapper.Map<ArticleQueryParameters>(queryParamsDto);
         var articles = await _repositoryManager.ArticleRepository.GetDeletedIncludeAsync(queryParams, false, cancellationToken);
         return new ArticlesGetResponse
         {

--- a/02. Business/NewHabr.Domain/Contracts/Services/IArticleService.cs
+++ b/02. Business/NewHabr.Domain/Contracts/Services/IArticleService.cs
@@ -13,11 +13,11 @@ public interface IArticleService
 
     Task<ArticleDto> GetByIdAsync(Guid id, CancellationToken cancellationToken);
 
-    Task<ArticlesGetResponse> GetPublishedAsync(ArticleQueryParameters queryParams, CancellationToken cancellationToken);
+    Task<ArticlesGetResponse> GetPublishedAsync(ArticleQueryParametersDto queryParams, CancellationToken cancellationToken);
 
-    Task<ArticlesGetResponse> GetUnpublishedAsync(ArticleQueryParameters queryParams, CancellationToken cancellationToken);
+    Task<ArticlesGetResponse> GetUnpublishedAsync(ArticleQueryParametersDto queryParams, CancellationToken cancellationToken);
 
-    Task<ArticlesGetResponse> GetDeletedAsync(ArticleQueryParameters queryParams, CancellationToken cancellationToken);
+    Task<ArticlesGetResponse> GetDeletedAsync(ArticleQueryParametersDto queryParams, CancellationToken cancellationToken);
 
     Task CreateAsync(ArticleCreateRequest request, Guid creatorId, CancellationToken cancellationToken);
 

--- a/02. Business/NewHabr.Domain/Dto/ArticleQueryParameters.cs
+++ b/02. Business/NewHabr.Domain/Dto/ArticleQueryParameters.cs
@@ -2,4 +2,9 @@
 
 public class ArticleQueryParameters : QueryParameters
 {
+    public DateTimeOffset From { get; set; }
+
+    public DateTimeOffset To { get; set; } = DateTimeOffset.UtcNow;
+
+    public string OrderBy { get; set; }
 }

--- a/02. Business/NewHabr.Domain/Dto/ArticleQueryParametersDto.cs
+++ b/02. Business/NewHabr.Domain/Dto/ArticleQueryParametersDto.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+
+namespace NewHabr.Domain.Dto;
+
+public class ArticleQueryParametersDto : QueryParameters
+{
+    [FromQuery(Name = QueryParametersDefinitions.FromDateTime)]
+    [Range(0, long.MaxValue)]
+    public long From { get; set; }
+
+    [FromQuery(Name = QueryParametersDefinitions.ToDateTime)]
+    [Range(0, long.MaxValue)]
+    public long To { get; set; } = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+    [FromQuery(Name = QueryParametersDefinitions.OrderBy)]
+    [StringLength(10)]
+    public string OrderBy { get; set; } = QueryParametersDefinitions.OrderingTypes.Descending;
+}

--- a/02. Business/NewHabr.Domain/Dto/ArticleQueryParametersDto.cs
+++ b/02. Business/NewHabr.Domain/Dto/ArticleQueryParametersDto.cs
@@ -6,11 +6,11 @@ namespace NewHabr.Domain.Dto;
 public class ArticleQueryParametersDto : QueryParameters
 {
     [FromQuery(Name = QueryParametersDefinitions.FromDateTime)]
-    [Range(0, long.MaxValue)]
+    [Range(-62135596800000, 253402300799999)]
     public long From { get; set; }
 
     [FromQuery(Name = QueryParametersDefinitions.ToDateTime)]
-    [Range(0, long.MaxValue)]
+    [Range(-62135596800000, 253402300799999)]
     public long To { get; set; } = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
     [FromQuery(Name = QueryParametersDefinitions.OrderBy)]

--- a/02. Business/NewHabr.Domain/Dto/QueryParameters.cs
+++ b/02. Business/NewHabr.Domain/Dto/QueryParameters.cs
@@ -1,12 +1,15 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
 
 namespace NewHabr.Domain.Dto;
 
 public class QueryParameters
 {
+    [FromQuery(Name = QueryParametersDefinitions.PageNumber)]
     [Range(1, int.MaxValue)]
     public virtual int PageNumber { get; set; } = 1;
 
+    [FromQuery(Name = QueryParametersDefinitions.PageSize)]
     [Range(1, 30)]
     public virtual int PageSize { get; set; } = 10;
 }

--- a/02. Business/NewHabr.Domain/NewHabr.Domain.csproj
+++ b/02. Business/NewHabr.Domain/NewHabr.Domain.csproj
@@ -17,5 +17,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
   </ItemGroup>
 </Project>

--- a/02. Business/NewHabr.Domain/QueryParametersDefinitions.cs
+++ b/02. Business/NewHabr.Domain/QueryParametersDefinitions.cs
@@ -1,0 +1,16 @@
+﻿namespace NewHabr.Domain;
+
+public struct QueryParametersDefinitions
+{
+    public struct OrderingTypes
+    {
+        public const string Ascending = "ascending";
+        public const string Descending = "descending";
+    }
+
+    public const string PageNumber = "pageNumber";
+    public const string PageSize = "pageSize";
+    public const string OrderBy = "orderBy";
+    public const string FromDateTime = "from";
+    public const string ToDateTime = "to";
+}

--- a/03. DAL/NewHabr.DAL/Extensions/QueryableExtensions.cs
+++ b/03. DAL/NewHabr.DAL/Extensions/QueryableExtensions.cs
@@ -1,11 +1,12 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
 using NewHabr.Domain;
 
 namespace NewHabr.DAL.Extensions;
 public static class QueryableExtensions
 {
-    public static async Task<PagedList<T>> ToPagedListAsync<T>(
-        this IQueryable<T> source,
+    public static async Task<PagedList<TEntity>> ToPagedListAsync<TEntity>(
+        this IQueryable<TEntity> source,
         int pageNumber,
         int pageSize,
         CancellationToken cancellationToken)
@@ -15,6 +16,24 @@ public static class QueryableExtensions
             .Skip((pageNumber - 1) * pageSize)
             .Take(pageSize)
             .ToListAsync(cancellationToken);
-        return new PagedList<T>(items, count, pageNumber, pageSize);
+        return new PagedList<TEntity>(items, count, pageNumber, pageSize);
+    }
+
+    public static IOrderedQueryable<TEntity> OrderByType<TEntity, TResult>(
+        this IQueryable<TEntity> source,
+        Expression<Func<TEntity, TResult>> keySelector,
+        string orderingType)
+    {
+        if (!string.IsNullOrWhiteSpace(orderingType))
+        {
+            orderingType = orderingType.Trim().ToLower();
+        }
+
+        return orderingType switch
+        {
+            QueryParametersDefinitions.OrderingTypes.Ascending => source.OrderBy(keySelector),
+            QueryParametersDefinitions.OrderingTypes.Descending => source.OrderByDescending(keySelector),
+            _ => source.OrderByDescending(keySelector),
+        };
     }
 }

--- a/03. DAL/NewHabr.DAL/Repository/ArticleRepository.cs
+++ b/03. DAL/NewHabr.DAL/Repository/ArticleRepository.cs
@@ -26,7 +26,7 @@ public class ArticleRepository : RepositoryBase<Article, Guid>, IArticleReposito
             .Include(a => a.Tags)
             .Include(a => a.Comments
                 .OrderBy(c => c.CreatedAt))
-            .OrderByType(a => a.CreatedAt, queryParams.OrderBy)
+            .OrderByType(a => a.PublishedAt, queryParams.OrderBy)
             .Select(ArticleToArticleExt())
             .ToPagedListAsync(queryParams.PageNumber, queryParams.PageSize, cancellationToken);
     }

--- a/03. DAL/NewHabr.DAL/Repository/ArticleRepository.cs
+++ b/03. DAL/NewHabr.DAL/Repository/ArticleRepository.cs
@@ -21,7 +21,7 @@ public class ArticleRepository : RepositoryBase<Article, Guid>, IArticleReposito
         CancellationToken cancellationToken)
     {
         return await FindByCondition(article => article.Published, trackChanges)
-            .Where(a => a.CreatedAt >= queryParams.From && a.CreatedAt <= queryParams.To)
+            .Where(a => a.PublishedAt >= queryParams.From && a.PublishedAt <= queryParams.To)
             .Include(a => a.Categories)
             .Include(a => a.Tags)
             .Include(a => a.Comments

--- a/03. DAL/NewHabr.DAL/Repository/ArticleRepository.cs
+++ b/03. DAL/NewHabr.DAL/Repository/ArticleRepository.cs
@@ -21,11 +21,12 @@ public class ArticleRepository : RepositoryBase<Article, Guid>, IArticleReposito
         CancellationToken cancellationToken)
     {
         return await FindByCondition(article => article.Published, trackChanges)
+            .Where(a => a.CreatedAt >= queryParams.From && a.CreatedAt <= queryParams.To)
             .Include(a => a.Categories)
             .Include(a => a.Tags)
             .Include(a => a.Comments
                 .OrderBy(c => c.CreatedAt))
-            .OrderByDescending(a => a.CreatedAt)
+            .OrderByType(a => a.CreatedAt, queryParams.OrderBy)
             .Select(ArticleToArticleExt())
             .ToPagedListAsync(queryParams.PageNumber, queryParams.PageSize, cancellationToken);
     }
@@ -37,11 +38,12 @@ public class ArticleRepository : RepositoryBase<Article, Guid>, IArticleReposito
         CancellationToken cancellationToken)
     {
         return await FindByCondition(a => a.Title.ToLower() == title.ToLower(), trackChanges)
+            .Where(a => a.CreatedAt >= queryParams.From && a.CreatedAt <= queryParams.To)
             .Include(a => a.Categories)
             .Include(a => a.Tags)
             .Include(a => a.Comments
                 .OrderBy(c => c.CreatedAt))
-            .OrderByDescending(a => a.CreatedAt)
+            .OrderByType(a => a.CreatedAt, queryParams.OrderBy)
             .Select(ArticleToArticleExt())
             .ToPagedListAsync(queryParams.PageNumber, queryParams.PageSize, cancellationToken);
     }
@@ -53,11 +55,12 @@ public class ArticleRepository : RepositoryBase<Article, Guid>, IArticleReposito
         CancellationToken cancellationToken)
     {
         return await FindByCondition(a => a.UserId == userId, trackChanges)
+            .Where(a => a.CreatedAt >= queryParams.From && a.CreatedAt <= queryParams.To)
             .Include(a => a.Categories)
             .Include(a => a.Tags)
             .Include(a => a.Comments
                 .OrderBy(c => c.CreatedAt))
-            .OrderByDescending(a => a.CreatedAt)
+            .OrderByType(a => a.CreatedAt, queryParams.OrderBy)
             .Select(ArticleToArticleExt())
             .ToPagedListAsync(queryParams.PageNumber, queryParams.PageSize, cancellationToken);
     }
@@ -68,11 +71,12 @@ public class ArticleRepository : RepositoryBase<Article, Guid>, IArticleReposito
         CancellationToken cancellationToken)
     {
         return await FindByCondition(a => !a.Published, trackChanges)
+            .Where(a => a.CreatedAt >= queryParams.From && a.CreatedAt <= queryParams.To)
             .Include(a => a.Categories)
             .Include(a => a.Tags)
             .Include(a => a.Comments
                 .OrderBy(c => c.CreatedAt))
-            .OrderByDescending(a => a.CreatedAt)
+            .OrderByType(a => a.CreatedAt, queryParams.OrderBy)
             .Select(ArticleToArticleExt())
             .ToPagedListAsync(queryParams.PageNumber, queryParams.PageSize, cancellationToken);
     }
@@ -83,12 +87,13 @@ public class ArticleRepository : RepositoryBase<Article, Guid>, IArticleReposito
         CancellationToken cancellationToken)
     {
         return await GetDeleted(trackChanges)
+            .Where(a => a.CreatedAt >= queryParams.From && a.CreatedAt <= queryParams.To)
             .IgnoreQueryFilters()
             .Include(a => a.Categories)
             .Include(a => a.Tags)
             .Include(a => a.Comments
                 .OrderBy(c => c.CreatedAt))
-            .OrderBy(a => a.DeletedAt)
+            .OrderByType(a => a.DeletedAt, queryParams.OrderBy)
             .Select(ArticleToArticleExt())
             .ToPagedListAsync(queryParams.PageNumber, queryParams.PageSize, cancellationToken);
     }


### PR DESCRIPTION
Есть касяк с выборкой по временным промежуткам.
Сценарий следующий:

Запрашиваем статьи сортируем их по порядку на основании времени создания.

![Query-1](https://user-images.githubusercontent.com/84354312/220343443-68f38fa8-38d1-4f49-b66f-40d47ae6ebe5.png)

Берем время создания первой.

![SelectArticle](https://user-images.githubusercontent.com/84354312/220342588-39648a20-df5c-44d6-b058-bdc35aa48b2b.png)

При попытке сделать выборку заканчивая датой первой статьи по логике указанной ниже, мы должны получить только одну статью (первую).

логика выборки: (a.CreatedAt >= queryParams.From && a.CreatedAt <= queryParams.To)

Делаем новый запрос.

![Query-2](https://user-images.githubusercontent.com/84354312/220344356-381d485f-3e68-4493-b5f8-5872950a179e.png)

Но получаем.

![Response-2](https://user-images.githubusercontent.com/84354312/220344825-00e300e5-ec31-450b-a0cb-f5b6d99aa5db.png)

Почему!
Вот пример

![Equality](https://user-images.githubusercontent.com/84354312/220351482-1d3bf083-44c3-49a5-aeda-6dd0452f1f7f.png)

Они не равны

Вот подробно

![Data](https://user-images.githubusercontent.com/84354312/220351676-e8da0ad1-97b7-4cf5-bafb-c96628633f40.png)

При преобразование в long происходит округление.

На данный момент мыслей по этому поводу у меня нет. С удовольствием послушаю ваши.